### PR TITLE
Fix cached_ganzhi decorator argument mismatch

### DIFF
--- a/src/tungshing/core.py
+++ b/src/tungshing/core.py
@@ -27,7 +27,7 @@ except Exception as _e:
 	# 中文：运行时必须安装 cnlunar 与 sxtwl；否则无法进行口径裁边与转发。
 	raise
 
-from .cache import cached_solar_term, cached_ganzhi, _global_cache
+# _global_cache not needed in this module
 from .validation import validate_input, safe_calculation, TungShingValidator
 
 
@@ -43,8 +43,6 @@ _JIE_IDX = {JQMC.index(n) for n in [
 	"立秋","白露","寒露","立冬","大雪","小寒",
 ]}  # 以“节”而非“中气”换月 / Use "Jié" (not "Zhongqi") to switch months
 
-
-@cached_ganzhi
 def _gz_str(gz) -> str:
 	"""
 	Convert ganzhi object to string representation with caching.


### PR DESCRIPTION
# Pull Request / 拉取请求

Thank you for contributing to TungShing! / 感谢您为 TungShing 做出贡献！

Please fill out this template to help us review your changes.
请填写此模板以帮助我们审查您的更改。

## Description / 描述

**Briefly describe what this PR does / 简要描述此 PR 的作用**

This PR removes the misapplied `@cached_ganzhi` decorator from `_gz_str` and cleans up related unused imports.

## Motivation and Context / 动机和上下文

**Why is this change required? What problem does it solve? / 为什么需要这个更改？它解决了什么问题？**

The `@cached_ganzhi` decorator was incorrectly applied to `_gz_str`. The decorator expects `year, month, day` arguments for cache key generation, but `_gz_str` only takes a `gz` object. This mismatch prevented the caching mechanism from functioning as intended, defeating its purpose.

## Type of Change / 更改类型

**What type of change does this PR introduce? / 此 PR 引入了什么类型的更改？**

- [x] Bug fix / 错误修复
- [ ] New feature / 新功能
- [ ] Breaking change / 破坏性更改
- [ ] Documentation update / 文档更新
- [ ] Performance improvement / 性能改进
- [ ] Code refactoring / 代码重构
- [ ] Test addition/improvement / 测试添加/改进

## Testing / 测试

**How has this been tested? Please describe the tests that you ran / 这是如何测试的？请描述您运行的测试**

Attempted to run existing tests, but encountered missing runtime dependencies (`cnlunar`, `sxtwl`). The changes were validated via static code analysis.

- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing performed (via static analysis)

## Checklist / 检查清单

**Please check all that apply / 请勾选所有适用的选项**

- [x] My code follows the style guidelines of this project / 我的代码遵循此项目的样式指南
- [x] I have performed a self-review of my own code / 我已对自己的代码进行了自我审查
- [ ] I have commented my code, particularly in hard-to-understand areas / 我已对代码进行注释，特别是在难以理解的区域
- [ ] I have made corresponding changes to the documentation / 我已对文档进行了相应的更改
- [x] My changes generate no new warnings / 我的更改不会产生新的警告
- [ ] I have added tests that prove my fix is effective or that my feature works / 我已添加证明我的修复有效或我的功能正常工作的测试
- [ ] New and existing unit tests pass locally with my changes / 新的和现有的单元测试在我的更改下本地通过
- [ ] Any dependent changes have been merged and published in downstream modules / 任何依赖更改都已在下游模块中合并和发布

## Additional Notes / 附加说明

**Any additional information that would be helpful / 任何有用的附加信息**

Test execution was attempted but halted due to missing runtime dependencies (`cnlunar`, `sxtwl`). The fix was validated via static code analysis.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8fce1fa-2a0e-4420-aefa-68903d77419d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a8fce1fa-2a0e-4420-aefa-68903d77419d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

